### PR TITLE
Create shex equivalents for shacl tests

### DIFF
--- a/__tests__/shacl11/shex/and-001.shex
+++ b/__tests__/shacl11/shex/and-001.shex
@@ -1,0 +1,10 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/and-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ex:AddressShape {
+  rdfs:label ["Address shape"] ;
+  ex:address {
+    ex:suburb . + ;
+    ex:postalCode . +
+  }
+}

--- a/__tests__/shacl11/shex/class-001.shex
+++ b/__tests__/shacl11/shex/class-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/class-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ex:TestShape {
+  ex:testProperty @ex:SuperClass ;
+  ex:testProperty { rdfs:label ["test property"] }
+}

--- a/__tests__/shacl11/shex/class-002.shex
+++ b/__tests__/shacl11/shex/class-002.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/class-002.test#>
+
+ex:TestShape {
+  ex:testProperty @ex:SuperClass
+}

--- a/__tests__/shacl11/shex/class-003.shex
+++ b/__tests__/shacl11/shex/class-003.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/class-003.test#>
+
+ex:TestShape {
+  ex:testProperty @ex:SuperClass
+}

--- a/__tests__/shacl11/shex/closed-001.shex
+++ b/__tests__/shacl11/shex/closed-001.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/node/closed-001.test#>
+
+ex:MyShape CLOSED {
+  ex:someProperty .
+}

--- a/__tests__/shacl11/shex/closed-002.shex
+++ b/__tests__/shacl11/shex/closed-002.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/node/closed-002.test#>
+
+ex:MyShape CLOSED {
+  ex:p1 . ;
+  ex:p2 .
+}

--- a/__tests__/shacl11/shex/datatype-001.shex
+++ b/__tests__/shacl11/shex/datatype-001.shex
@@ -1,0 +1,11 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/datatype-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ex:dateProperty xsd:date ;
+  ex:dateProperty { rdfs:label ["date property"] } ;
+  ex:integerProperty xsd:integer ;
+  ex:integerProperty { rdfs:label ["integer property"] }
+}

--- a/__tests__/shacl11/shex/datatype-002.shex
+++ b/__tests__/shacl11/shex/datatype-002.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/datatype-002.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:value xsd:string
+}

--- a/__tests__/shacl11/shex/datatype-003.shex
+++ b/__tests__/shacl11/shex/datatype-003.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/datatype-003.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:value xsd:string
+}

--- a/__tests__/shacl11/shex/deactivated-001.shex
+++ b/__tests__/shacl11/shex/deactivated-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/deactivated-001.test#>
+
+# Note: ShEx doesn't have a direct equivalent for deactivated shapes
+# This shape would always validate
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/deactivated-002.shex
+++ b/__tests__/shacl11/shex/deactivated-002.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/deactivated-002.test#>
+
+# Note: ShEx doesn't have a direct equivalent for deactivated shapes
+# This shape would always validate
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/disjoint-001.shex
+++ b/__tests__/shacl11/shex/disjoint-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/disjoint-001.test#>
+
+# Note: ShEx doesn't have a direct equivalent for disjoint constraint
+# This would need to be enforced at the application level
+ex:TestShape {
+  ex:property1 . * ;
+  ex:property2 . *
+}

--- a/__tests__/shacl11/shex/equals-001.shex
+++ b/__tests__/shacl11/shex/equals-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/equals-001.test#>
+
+# Note: ShEx doesn't have a direct equivalent for equals constraint
+# This would need to be enforced at the application level
+ex:TestShape {
+  ex:property1 . * ;
+  ex:property2 . *
+}

--- a/__tests__/shacl11/shex/hasValue-001.shex
+++ b/__tests__/shacl11/shex/hasValue-001.shex
@@ -1,0 +1,9 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/hasValue-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:PersonShape EXTRA ex:gender {
+  rdfs:label ["Person shape"] ;
+  ex:gender ["male"] ;
+  ex:gender { rdfs:label ["gender"] }
+}

--- a/__tests__/shacl11/shex/in-001.shex
+++ b/__tests__/shacl11/shex/in-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/in-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:ShapeClass {
+  ex:property ["A" "B" "C"]
+}

--- a/__tests__/shacl11/shex/languageIn-001.shex
+++ b/__tests__/shacl11/shex/languageIn-001.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/languageIn-001.test#>
+
+ex:NewZealandLanguagesShape {
+  ex:prefLabel [@en @mi]
+}

--- a/__tests__/shacl11/shex/lessThan-001.shex
+++ b/__tests__/shacl11/shex/lessThan-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/lessThan-001.test#>
+
+# Note: ShEx doesn't have a direct equivalent for lessThan constraint between properties
+# This would need to be enforced at the application level
+ex:TestShape {
+  ex:startDate . ;
+  ex:endDate .
+}

--- a/__tests__/shacl11/shex/lessThan-002.shex
+++ b/__tests__/shacl11/shex/lessThan-002.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/lessThan-002.test#>
+
+# Note: ShEx doesn't have a direct equivalent for lessThan constraint between properties
+# This would need to be enforced at the application level
+ex:TestShape {
+  ex:startDate . ;
+  ex:endDate .
+}

--- a/__tests__/shacl11/shex/lessThanOrEquals-001.shex
+++ b/__tests__/shacl11/shex/lessThanOrEquals-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#>
+
+# Note: ShEx doesn't have a direct equivalent for lessThanOrEquals constraint between properties
+# This would need to be enforced at the application level
+ex:TestShape {
+  ex:startDate . ;
+  ex:endDate .
+}

--- a/__tests__/shacl11/shex/maxCount-001.shex
+++ b/__tests__/shacl11/shex/maxCount-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/maxCount-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:PersonShape {
+  ex:firstName xsd:string ?
+}

--- a/__tests__/shacl11/shex/maxCount-002.shex
+++ b/__tests__/shacl11/shex/maxCount-002.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/maxCount-002.test#>
+
+ex:TestShape {
+  ex:property . {0,2}
+}

--- a/__tests__/shacl11/shex/maxExclusive-001.shex
+++ b/__tests__/shacl11/shex/maxExclusive-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:property xsd:integer MAXEXCLUSIVE 1
+}

--- a/__tests__/shacl11/shex/maxInclusive-001.shex
+++ b/__tests__/shacl11/shex/maxInclusive-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:property xsd:integer MAXINCLUSIVE 1
+}

--- a/__tests__/shacl11/shex/maxLength-001.shex
+++ b/__tests__/shacl11/shex/maxLength-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/maxLength-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ex:testProperty xsd:string MAXLENGTH 2
+}

--- a/__tests__/shacl11/shex/message-001.shex
+++ b/__tests__/shacl11/shex/message-001.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/misc/message-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape xsd:integer 
+  // %% "Test message"@en

--- a/__tests__/shacl11/shex/minCount-001.shex
+++ b/__tests__/shacl11/shex/minCount-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minCount-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:PersonShape {
+  ex:firstName xsd:string +
+}

--- a/__tests__/shacl11/shex/minCount-002.shex
+++ b/__tests__/shacl11/shex/minCount-002.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minCount-002.test#>
+
+ex:TestShape {
+  ex:property . {2,*}
+}

--- a/__tests__/shacl11/shex/minExclusive-001.shex
+++ b/__tests__/shacl11/shex/minExclusive-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ex:testProperty xsd:integer MINEXCLUSIVE 40
+}

--- a/__tests__/shacl11/shex/minExclusive-002.shex
+++ b/__tests__/shacl11/shex/minExclusive-002.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:property xsd:integer MINEXCLUSIVE 0
+}

--- a/__tests__/shacl11/shex/minInclusive-001.shex
+++ b/__tests__/shacl11/shex/minInclusive-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minInclusive-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:property xsd:integer MININCLUSIVE 0
+}

--- a/__tests__/shacl11/shex/minInclusive-002.shex
+++ b/__tests__/shacl11/shex/minInclusive-002.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minInclusive-002.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:property xsd:date MININCLUSIVE "2000-01-01"^^xsd:date
+}

--- a/__tests__/shacl11/shex/minInclusive-003.shex
+++ b/__tests__/shacl11/shex/minInclusive-003.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minInclusive-003.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  ex:property xsd:integer MININCLUSIVE 1
+}

--- a/__tests__/shacl11/shex/minLength-001.shex
+++ b/__tests__/shacl11/shex/minLength-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/minLength-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ex:testProperty xsd:string MINLENGTH 2
+}

--- a/__tests__/shacl11/shex/multipleTargets-001.shex
+++ b/__tests__/shacl11/shex/multipleTargets-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+# Note: ShEx doesn't have target declarations like SHACL
+# Targets would be specified when validating
+ex:TestShape [ex:ValidResource1 ex:ValidResource2] {
+  rdfs:label ["Test shape"]
+}

--- a/__tests__/shacl11/shex/node-001.shex
+++ b/__tests__/shacl11/shex/node-001.shex
@@ -1,0 +1,19 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/node-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:Person {
+  rdfs:label ["Person"] ;
+  ex:email xsd:string * ;
+  ex:firstName xsd:string ;
+  ex:lastName xsd:string *
+}
+
+ex:Issue {
+  rdfs:label ["Issue"] ;
+  ex:assignedTo @ex:Person AND {
+    ex:email . ;
+    ex:lastName .
+  } ;
+  ex:submittedBy @ex:Person +
+}

--- a/__tests__/shacl11/shex/node-002.shex
+++ b/__tests__/shacl11/shex/node-002.shex
@@ -1,0 +1,10 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/node-002.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:AddressShape {
+  ex:postalCode xsd:string ?
+}
+
+ex:PersonShape {
+  ex:address @ex:AddressShape +
+}

--- a/__tests__/shacl11/shex/nodeKind-001.shex
+++ b/__tests__/shacl11/shex/nodeKind-001.shex
@@ -1,0 +1,25 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/nodeKind-001.test#>
+
+ex:ShapeWithBlankNode {
+  ex:myProperty BNODE
+}
+
+ex:ShapeWithBlankNodeOrIRI {
+  ex:myProperty NONLITERAL
+}
+
+ex:ShapeWithBlankNodeOrLiteral {
+  ex:myProperty .
+}
+
+ex:ShapeWithIRI {
+  ex:myProperty IRI
+}
+
+ex:ShapeWithIRIOrLiteral {
+  ex:myProperty .
+}
+
+ex:ShapeWithLiteral {
+  ex:myProperty LITERAL
+}

--- a/__tests__/shacl11/shex/not-001.shex
+++ b/__tests__/shacl11/shex/not-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/node/not-001#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  NOT { ex:property . + }
+}

--- a/__tests__/shacl11/shex/not-002.shex
+++ b/__tests__/shacl11/shex/not-002.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/node/not-002.test#>
+
+ex:TestShape {
+  NOT { ex:property . + }
+}

--- a/__tests__/shacl11/shex/or-001.shex
+++ b/__tests__/shacl11/shex/or-001.shex
@@ -1,0 +1,11 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/node/or-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ex:RectangleWithArea {
+  (
+    ex:height . + ;
+    ex:width . +
+  ) | (
+    ex:area . +
+  )
+}

--- a/__tests__/shacl11/shex/or-datatypes-001.shex
+++ b/__tests__/shacl11/shex/or-datatypes-001.shex
@@ -1,0 +1,9 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  rdfs:comment xsd:string OR rdf:HTML OR rdf:langString OR xsd:boolean
+}

--- a/__tests__/shacl11/shex/path-alternative-001.shex
+++ b/__tests__/shacl11/shex/path-alternative-001.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#>
+
+ex:TestShape {
+  (ex:name | ex:firstName) .
+}

--- a/__tests__/shacl11/shex/path-complex-001.shex
+++ b/__tests__/shacl11/shex/path-complex-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#>
+
+# Note: ShEx doesn't support complex SHACL paths directly
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-complex-002-shapes.shex
+++ b/__tests__/shacl11/shex/path-complex-002-shapes.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-complex-002.test#>
+
+# Note: ShEx doesn't support complex SHACL paths directly
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-inverse-001.shex
+++ b/__tests__/shacl11/shex/path-inverse-001.shex
@@ -1,0 +1,12 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+ex:Person {
+  rdfs:label ["Person"]
+}
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ^ex:child . {2}
+}

--- a/__tests__/shacl11/shex/path-oneOrMore-001.shex
+++ b/__tests__/shacl11/shex/path-oneOrMore-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#>
+
+# Note: ShEx doesn't support SHACL's oneOrMore path modifier
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-sequence-001.shex
+++ b/__tests__/shacl11/shex/path-sequence-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#>
+
+# Note: ShEx doesn't support SHACL's sequence paths
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-sequence-002.shex
+++ b/__tests__/shacl11/shex/path-sequence-002.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#>
+
+# Note: ShEx doesn't support SHACL's sequence paths
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-sequence-duplicate-001.shex
+++ b/__tests__/shacl11/shex/path-sequence-duplicate-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#>
+
+# Note: ShEx doesn't support SHACL's sequence paths
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-strange-001.shex
+++ b/__tests__/shacl11/shex/path-strange-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-strange-001.test#>
+
+# Note: ShEx doesn't support complex SHACL paths
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-strange-002.shex
+++ b/__tests__/shacl11/shex/path-strange-002.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-strange-002.test#>
+
+# Note: ShEx doesn't support complex SHACL paths
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-unused-001-shapes.shex
+++ b/__tests__/shacl11/shex/path-unused-001-shapes.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-unused-001.test#>
+
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-zeroOrMore-001.shex
+++ b/__tests__/shacl11/shex/path-zeroOrMore-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#>
+
+# Note: ShEx doesn't support SHACL's zeroOrMore path modifier
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/path-zeroOrOne-001.shex
+++ b/__tests__/shacl11/shex/path-zeroOrOne-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#>
+
+# Note: ShEx doesn't support SHACL's zeroOrOne path modifier
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/pattern-001.shex
+++ b/__tests__/shacl11/shex/pattern-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/pattern-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ex:property /Joh/
+}

--- a/__tests__/shacl11/shex/pattern-002.shex
+++ b/__tests__/shacl11/shex/pattern-002.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/pattern-002.test#>
+
+ex:TestShape {
+  ex:property /^ex:/
+}

--- a/__tests__/shacl11/shex/personexample.shex
+++ b/__tests__/shacl11/shex/personexample.shex
@@ -1,0 +1,10 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/complex/personexample.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+ex:PersonShape CLOSED EXTRA rdf:type {
+  ex:ssn /^\\d{3}-\\d{2}-\\d{4}$/ ? ;
+  ex:worksFor IRI ;
+  ^ex:worksFor . * // %% sh:name "employee"
+}

--- a/__tests__/shacl11/shex/property-001.shex
+++ b/__tests__/shacl11/shex/property-001.shex
@@ -1,0 +1,13 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/property-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ex:City {
+  rdfs:label ["City"]
+}
+
+ex:PersonShape {
+  rdfs:label ["Person shape"] ;
+  ex:address {
+    ex:city @ex:City
+  }
+}

--- a/__tests__/shacl11/shex/qualified-001-shapes.shex
+++ b/__tests__/shacl11/shex/qualified-001-shapes.shex
@@ -1,0 +1,9 @@
+PREFIX ex: <http://example.org/shacl-test/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+# Note: ShEx doesn't have direct equivalents for qualified cardinality constraints
+# sh:qualifiedValueShapesDisjoint, sh:qualifiedMinCount, sh:qualifiedMaxCount
+# This would need to be enforced at the application level
+ex:s1 {
+  . *
+}

--- a/__tests__/shacl11/shex/qualifiedMinCountDisjoint-001.shex
+++ b/__tests__/shacl11/shex/qualifiedMinCountDisjoint-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#>
+
+# Note: ShEx doesn't have direct equivalents for qualified cardinality constraints
+# This would need to be enforced at the application level
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/qualifiedValueShape-001.shex
+++ b/__tests__/shacl11/shex/qualifiedValueShape-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#>
+
+# Note: ShEx doesn't have direct equivalents for qualified value shapes
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/qualifiedValueShapesDisjoint-001.shex
+++ b/__tests__/shacl11/shex/qualifiedValueShapesDisjoint-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#>
+
+# Note: ShEx doesn't have direct equivalents for qualified value shapes disjoint constraint
+# This would need to be modeled differently
+ex:TestShape {
+  . *
+}

--- a/__tests__/shacl11/shex/severity-001.shex
+++ b/__tests__/shacl11/shex/severity-001.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/misc/severity-001.test#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Note: ShEx doesn't have severity levels like SHACL's Warning
+# This is just the constraint without severity
+ex:TestShape xsd:integer

--- a/__tests__/shacl11/shex/shacl-shacl-data-shapes.shex
+++ b/__tests__/shacl11/shex/shacl-shacl-data-shapes.shex
@@ -1,0 +1,8 @@
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+# Note: This is a meta-schema for SHACL itself
+# ShEx equivalent would be very complex
+# Placeholder for SHACL meta-validation
+sh:Shape {
+  . *
+}

--- a/__tests__/shacl11/shex/shared-shapes.shex
+++ b/__tests__/shacl11/shex/shared-shapes.shex
@@ -1,0 +1,6 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/misc/shared-shapes.test#>
+
+# Shared shapes in ShEx
+ex:SharedShape {
+  . *
+}

--- a/__tests__/shacl11/shex/targetClass-001.shex
+++ b/__tests__/shacl11/shex/targetClass-001.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/targetClass-001.test#>
+
+ex:MyShape {
+  ex:myProperty . ?
+}

--- a/__tests__/shacl11/shex/targetClassImplicit-001.shex
+++ b/__tests__/shacl11/shex/targetClassImplicit-001.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#>
+
+ex:TestShape {
+  ex:myProperty . ?
+}

--- a/__tests__/shacl11/shex/targetNode-001.shex
+++ b/__tests__/shacl11/shex/targetNode-001.shex
@@ -1,0 +1,10 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/targetNode-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Note: ShEx doesn't have target declarations
+# The constraint is that rdfs:label should not exist (maxCount 0)
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  rdfs:label . {0}  # No rdfs:label allowed on target nodes
+}

--- a/__tests__/shacl11/shex/targetObjectsOf-001.shex
+++ b/__tests__/shacl11/shex/targetObjectsOf-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/targetObjectsOf-001.test#>
+
+# Note: ShEx doesn't have targetObjectsOf
+# This would be applied to objects of the specified property
+ex:TestShape {
+  ex:myProperty . ?
+}

--- a/__tests__/shacl11/shex/targetSubjectsOf-001.shex
+++ b/__tests__/shacl11/shex/targetSubjectsOf-001.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#>
+
+# Note: ShEx doesn't have targetSubjectsOf
+# This would be applied to subjects of the specified property
+ex:TestShape {
+  ex:knows . +
+}

--- a/__tests__/shacl11/shex/targetSubjectsOf-002.shex
+++ b/__tests__/shacl11/shex/targetSubjectsOf-002.shex
@@ -1,0 +1,7 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#>
+
+# Note: ShEx doesn't have targetSubjectsOf
+# This would be applied to subjects of the specified property
+ex:TestShape {
+  ex:knows . +
+}

--- a/__tests__/shacl11/shex/uniqueLang-001.shex
+++ b/__tests__/shacl11/shex/uniqueLang-001.shex
@@ -1,0 +1,8 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ex:TestShape {
+  rdfs:label ["Test shape"] ;
+  ex:testProperty . * UNIQUELANG ;
+  ex:testProperty { rdfs:label ["test property"] }
+}

--- a/__tests__/shacl11/shex/uniqueLang-002-shapes.shex
+++ b/__tests__/shacl11/shex/uniqueLang-002-shapes.shex
@@ -1,0 +1,5 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-002.test#>
+
+ex:TestShape {
+  ex:testProperty . * UNIQUELANG
+}

--- a/__tests__/shacl11/shex/xone-001.shex
+++ b/__tests__/shacl11/shex/xone-001.shex
@@ -1,0 +1,13 @@
+PREFIX ex: <http://datashapes.org/sh/tests/core/node/xone-001.test#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+# ShEx doesn't have direct xone (exactly one) support
+# This approximates it with oneOf
+ex:XoneConstraintExampleShape (
+  { ex:fullName . + }
+  |
+  { 
+    ex:firstName . + ;
+    ex:lastName . +
+  }
+)

--- a/__tests__/shacl11/shex/xone-duplicate-shapes.shex
+++ b/__tests__/shacl11/shex/xone-duplicate-shapes.shex
@@ -1,0 +1,9 @@
+PREFIX ex: <http://example.org/shacl-test/>
+
+ex:s2 {
+  a [ex:C2]
+}
+
+# ShEx doesn't have direct xone support
+# The duplicate reference to ex:s2 in xone would be handled differently
+ex:s1 @ex:s2


### PR DESCRIPTION
Adds manually created ShEx equivalents for all SHACL test files in `__tests__/shacl11`.

These files translate SHACL constraints to ShEx, with comments indicating where direct ShEx equivalents are not available for certain SHACL features (e.g., `deactivated`, `disjoint`, `equals`, `lessThan`, `qualified cardinality`, `severity`, complex paths, `xone`).

---

[Open in Web](https://cursor.com/agents?id=bc-8ebf1a1b-12b5-456b-9d00-848e5a6b7ccc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8ebf1a1b-12b5-456b-9d00-848e5a6b7ccc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)