### PR TITLE
Add commonjs support to library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,14 +1692,14 @@
       }
     },
     "node_modules/@ldo/cli": {
-      "version": "0.0.1-1.0.0-alpha.1.0",
-      "resolved": "https://registry.npmjs.org/@ldo/cli/-/cli-0.0.1-1.0.0-alpha.1.0.tgz",
-      "integrity": "sha512-kaA9XNyWTFH8zdeP/9T3Aq1ak5QOmww/lEkOVDQ/0ymqOXWPdxffiFAEidm658ybdNfUVcJ1gvSGsYvXgUjBGA==",
+      "version": "0.0.1-alpha.32",
+      "resolved": "https://registry.npmjs.org/@ldo/cli/-/cli-0.0.1-alpha.32.tgz",
+      "integrity": "sha512-EUmhZrlEx8IW2M0e6zp7j19iGfRsehHZFz6Cz+qdo3PxSYVLkrUIS/6ZuPt7xFJXPCbkGOnmkcJykCJeIbflVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ldo/ldo": "^0.0.1-1.0.0-alpha.1.0",
-        "@ldo/schema-converter-shex": "^0.0.1-1.0.0-alpha.1.0",
+        "@ldo/ldo": "^0.0.1-alpha.29",
+        "@ldo/schema-converter-shex": "^0.0.1-alpha.29",
         "@shexjs/parser": "^1.0.0-alpha.24",
         "child-process-promise": "^2.2.1",
         "commander": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,22 @@
   "name": "@jeswr/shacl2shex",
   "version": "0.0.0-development",
   "description": "Convert SHACL to ShEx",
-  "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "directories": {
     "lib": "lib"
   },
@@ -16,10 +30,13 @@
     "test": "jest",
     "lint": "eslint lib/* __tests__/*.ts --ext .ts",
     "lint:fix": "eslint lib/* __tests__/*.ts --ext .ts --fix",
-    "fetch:shape": "./dist/bin/index.js https://www.w3.org/ns/shacl-shacl#ShapeShape scripts/Shacl.shex",
+    "fetch:shape": "./dist/cjs/bin/index.js https://www.w3.org/ns/shacl-shacl#ShapeShape scripts/Shacl.shex",
     "ldo": "ldo build --input ./scripts --output ./lib/ldo",
-    "build": "tsc",
-    "prepare": "tsc",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:post",
+    "build:cjs": "tsc",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:post": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json && echo '{\"type\":\"module\"}' > dist/esm/package.json && node scripts/fix-esm-imports.js",
+    "prepare": "npm run build",
     "semantic-release": "semantic-release"
   },
   "repository": {
@@ -110,6 +127,6 @@
     "rdf-namespaces": "^1.12.0"
   },
   "bin": {
-    "shacl2shex": "dist/bin/index.js"
+    "shacl2shex": "dist/cjs/bin/index.js"
   }
 }

--- a/scripts/fix-esm-imports.js
+++ b/scripts/fix-esm-imports.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+function fixEsmImports(dir) {
+  const files = fs.readdirSync(dir, { withFileTypes: true });
+  
+  for (const file of files) {
+    const filePath = path.join(dir, file.name);
+    
+    if (file.isDirectory()) {
+      fixEsmImports(filePath);
+    } else if (file.name.endsWith('.js')) {
+      let content = fs.readFileSync(filePath, 'utf8');
+      
+      // Fix relative imports without .js extension
+      content = content.replace(
+        /from\s+['"](\.[^'"]+)(?<!\.js)['"];?/g,
+        (match, importPath) => {
+          // Don't add .js if it's already there or if it's a directory import
+          if (importPath.endsWith('.js') || importPath.endsWith('/')) {
+            return match;
+          }
+          return match.replace(importPath, importPath + '.js');
+        }
+      );
+      
+      // Fix export from statements
+      content = content.replace(
+        /export\s+.*?\s+from\s+['"](\.[^'"]+)(?<!\.js)['"];?/g,
+        (match, importPath) => {
+          if (importPath.endsWith('.js') || importPath.endsWith('/')) {
+            return match;
+          }
+          return match.replace(importPath, importPath + '.js');
+        }
+      );
+      
+      fs.writeFileSync(filePath, content, 'utf8');
+    }
+  }
+}
+
+// Run the fix on the ESM output directory
+const esmDir = path.join(__dirname, '..', 'dist', 'esm');
+console.log('Fixing ESM imports in:', esmDir);
+fixEsmImports(esmDir);
+console.log('ESM imports fixed!');

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "outDir": "./dist/esm",
+    "declaration": true,
+    "declarationMap": true,
+    "moduleResolution": "node"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,10 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist/cjs",                        /* Redirect output structure to the directory. */
     "rootDir": "./lib",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */


### PR DESCRIPTION
Add dual package support for CommonJS and ESM to improve library compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d107e2b-47ba-4f86-b8bb-90b87383c53b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d107e2b-47ba-4f86-b8bb-90b87383c53b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

