### PR TITLE
Add commonjs support to library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,14 +1692,14 @@
       }
     },
     "node_modules/@ldo/cli": {
-      "version": "0.0.1-1.0.0-alpha.1.0",
-      "resolved": "https://registry.npmjs.org/@ldo/cli/-/cli-0.0.1-1.0.0-alpha.1.0.tgz",
-      "integrity": "sha512-kaA9XNyWTFH8zdeP/9T3Aq1ak5QOmww/lEkOVDQ/0ymqOXWPdxffiFAEidm658ybdNfUVcJ1gvSGsYvXgUjBGA==",
+      "version": "0.0.1-alpha.32",
+      "resolved": "https://registry.npmjs.org/@ldo/cli/-/cli-0.0.1-alpha.32.tgz",
+      "integrity": "sha512-EUmhZrlEx8IW2M0e6zp7j19iGfRsehHZFz6Cz+qdo3PxSYVLkrUIS/6ZuPt7xFJXPCbkGOnmkcJykCJeIbflVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ldo/ldo": "^0.0.1-1.0.0-alpha.1.0",
-        "@ldo/schema-converter-shex": "^0.0.1-1.0.0-alpha.1.0",
+        "@ldo/ldo": "^0.0.1-alpha.29",
+        "@ldo/schema-converter-shex": "^0.0.1-alpha.29",
         "@shexjs/parser": "^1.0.0-alpha.24",
         "child-process-promise": "^2.2.1",
         "commander": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,17 @@
   "name": "@jeswr/shacl2shex",
   "version": "0.0.0-development",
   "description": "Convert SHACL to ShEx",
-  "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "module": "./dist/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "directories": {
     "lib": "lib"
   },
@@ -18,8 +27,8 @@
     "lint:fix": "eslint lib/* __tests__/*.ts --ext .ts --fix",
     "fetch:shape": "./dist/bin/index.js https://www.w3.org/ns/shacl-shacl#ShapeShape scripts/Shacl.shex",
     "ldo": "ldo build --input ./scripts --output ./lib/ldo",
-    "build": "tsc",
-    "prepare": "tsc",
+    "build": "tsc && cp dist/index.js dist/index.cjs",
+    "prepare": "npm run build",
     "semantic-release": "semantic-release"
   },
   "repository": {


### PR DESCRIPTION
Add CommonJS support to the library to enable `require()` usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce27d9cd-7fab-45fe-b608-123040b84e8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce27d9cd-7fab-45fe-b608-123040b84e8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

