### PR TITLE
Add logical constraint support to shacl2shex

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -289,6 +289,89 @@ export async function shaclStoreToShexSchema(shapeStore: Store): Promise<Schema>
       }
     }
 
+    // ---------------------------------------------------------------------------
+    // Logical constraints: sh:and, sh:or, sh:not, sh:xone  (SHACL §2.3 Logical)
+    // ---------------------------------------------------------------------------
+    // According to the SHACL specification (https://www.w3.org/TR/shacl/#logical-constraint-components),
+    // a NodeShape may include logical constraint components. ShEx provides equivalent
+    // logical shape expressions (https://shex.io/shex-semantics/) – namely ShapeAnd,
+    // ShapeOr and ShapeNot – that can be used to express these constraints.
+    //
+    // Mapping rationale:
+    //   * sh:and  -> ShEx ShapeAnd (node must satisfy *all* listed shapes).
+    //   * sh:or   -> ShEx ShapeOr  (node must satisfy *at least one* listed shape).
+    //   * sh:not  -> ShEx ShapeNot (node must *not* satisfy the given shape).
+    //   * sh:xone -> There is no direct equivalent in ShEx2. We approximate it
+    //                using ShapeOr (same as sh:or). This ensures *at least* one
+    //                shape holds; exclusivity cannot currently be enforced in ShEx.
+    //                The relevant part of the SHACL spec is
+    //                https://www.w3.org/TR/shacl/#XoneConstraintComponent.
+    //
+    // After constructing the property-based shapeExpr above, we inspect the current
+    // shape for logical constraints and combine them with the property expression
+    // using an outer ShapeAnd (since both the property constraints *and* the logical
+    // constraint component must hold for the SHACL shape to validate).
+
+    const logicalAnd = shapeStore.getObjects(shape, namedNode(shacl.and), defaultGraph());
+    const logicalOr = shapeStore.getObjects(shape, namedNode(shacl.or), defaultGraph());
+    const logicalNot = shapeStore.getObjects(shape, namedNode(shacl.not), defaultGraph());
+    const logicalXone = shapeStore.getObjects(shape, namedNode(shacl.xone), defaultGraph());
+
+    // Helper to convert an RDF term to a ShEx shape expression reference
+    function termToShapeExpr(t: Term): shapeExprOrRef {
+      if (t.termType === 'NamedNode' || t.termType === 'BlankNode') {
+        return t.value;
+      }
+      console.warn('Unsupported term in logical constraint', t);
+      return t.value as any;
+    }
+
+    let logicalExpr: any;
+
+    if (logicalAnd.length === 1) {
+      const list = shapeStore.extractLists()[logicalAnd[0].value];
+      if (list) {
+        logicalExpr = {
+          type: 'ShapeAnd',
+          shapeExprs: list.map(termToShapeExpr),
+        };
+      }
+    } else if (logicalOr.length === 1) {
+      const list = shapeStore.extractLists()[logicalOr[0].value];
+      if (list) {
+        logicalExpr = {
+          type: 'ShapeOr',
+          shapeExprs: list.map(termToShapeExpr),
+        };
+      }
+    } else if (logicalNot.length === 1) {
+      logicalExpr = {
+        type: 'ShapeNot',
+        shapeExpr: termToShapeExpr(logicalNot[0]),
+      };
+    } else if (logicalXone.length === 1) {
+      // Note: Exclusivity cannot be guaranteed in ShEx2 – we degrade gracefully.
+      const list = shapeStore.extractLists()[logicalXone[0].value];
+      if (list) {
+        logicalExpr = {
+          type: 'ShapeOr',
+          shapeExprs: list.map(termToShapeExpr),
+        };
+      }
+    }
+
+    // Combine the logical expression with the previously computed shapeExpr
+    if (logicalExpr) {
+      if (shapeExpr) {
+        shapeExpr = {
+          type: 'ShapeAnd',
+          shapeExprs: [shapeExpr, logicalExpr],
+        };
+      } else {
+        shapeExpr = logicalExpr;
+      }
+    }
+
     shexShapes.push({
       id: shape.value,
       type: 'ShapeDecl',


### PR DESCRIPTION
Adds support for SHACL logical constraints (sh:and, sh:or, sh:not, sh:xone) to ShEx conversion, approximating `sh:xone` due to ShEx limitations.

---
<a href="https://cursor.com/background-agent?bcId=bc-de472e1d-ce42-4f75-93ca-a88b193963d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de472e1d-ce42-4f75-93ca-a88b193963d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

