### PR TITLE
chore: remove major packages from minor group type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     groups:
       minor:
         update-types:
-        - "major"
         - "minor"
         - "patch"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exclude major updates from the Dependabot npm "minor" group, leaving only minor and patch.
> 
> - **Dependabot config (`.github/dependabot.yml`)**:
>   - Update npm group `minor` to remove `"major"` from `update-types` (now only `"minor"` and `"patch"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 932d36358f94d1741ea4c0da2996319c4e73b36b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->